### PR TITLE
Admin port

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,16 @@
 
 ## Usage
 
+`go-infrabin` exposes two ports:
+
+* `8888` as a service port
+* `8899` as the admin port, for livensss and readiness probes
+
 To override the default values:
 
 * _INFRABIN_MAX_DELAY_ to change the maximum value for the `/delay` endpoint. Default to 120.
 
-## Endpoints
+## Service Endpoints
 
 * `GET /`
   * _returns_: a JSON response
@@ -38,7 +43,9 @@ To override the default values:
     }
     ```
 
-* `GET /healthcheck/liveness`
+## Admin Endpoints
+
+* `GET /liveness`
   * _returns_: a JSON response if healthy or the status code `503` if unhealthy.
 
     ```json

--- a/cmd/go-infrabin/main.go
+++ b/cmd/go-infrabin/main.go
@@ -53,19 +53,12 @@ func LivenessHandler(w http.ResponseWriter, r *http.Request) {
 // DelayHandler handles the "/delay" endpoint
 func DelayHandler(w http.ResponseWriter, r *http.Request) {
 	var resp helpers.Response
-	var val string
 	var seconds int
 	vars := mux.Vars(r)
 	w.Header().Set("Content-Type", "application/json")
-	val, ok := vars["seconds"]
-	if !ok {
-		seconds = 0
-	}
 
-	seconds, err := strconv.Atoi(val)
-
+	seconds, err := strconv.Atoi(vars["seconds"])
 	if err != nil {
-		log.Printf("cannot convert vars['seconds'] to integer: %v", err)
 		resp.Error = "cannot convert seconds to integer"
 		data := helpers.MarshalResponseToString(resp)
 		w.WriteHeader(http.StatusBadRequest)

--- a/cmd/go-infrabin/main_test.go
+++ b/cmd/go-infrabin/main_test.go
@@ -105,9 +105,7 @@ func TestLivenessHandler(t *testing.T) {
 	}
 
 	var expected helpers.Response
-	expected.ProbeResponse = &helpers.ProbeResponse{
-		Liveness: "pass",
-	}
+	expected.Liveness = "pass"
 	data := helpers.MarshalResponseToString(expected)
 
 	if rr.Body.String() != data {

--- a/internal/helpers/struct.go
+++ b/internal/helpers/struct.go
@@ -7,11 +7,11 @@ import (
 
 // Response creates the go-infrabin main response
 type Response struct {
-	Hostname      string         `json:"hostname,omitempty"`
-	KubeResponse  *KubeResponse  `json:"kubernetes,omitempty"`
-	ProbeResponse *ProbeResponse `json:"probes,omitempty"`
-	Delay         string         `json:"delay,omitempty"`
-	Error         string         `json:"error,omitempty"`
+	Hostname     string        `json:"hostname,omitempty"`
+	KubeResponse *KubeResponse `json:"kubernetes,omitempty"`
+	Liveness     string        `json:"liveness,omitempty"`
+	Delay        string        `json:"delay,omitempty"`
+	Error        string        `json:"error,omitempty"`
 }
 
 // KubeResponse creates the response if running on Kubernetes
@@ -20,12 +20,6 @@ type KubeResponse struct {
 	Namespace string `json:"namespace,omitempty"`
 	PodIP     string `json:"pod_ip,omitempty"`
 	NodeName  string `json:"node_name,omitempty"`
-}
-
-// ProbeResponse creates the liveness and reasiness probes response
-type ProbeResponse struct {
-	Liveness  string `json:"liveness,omitempty"`
-	Readiness string `json:"readiness,omitempty"`
 }
 
 // MarshalResponseToString marhal a Response struct into a json and return it as string


### PR DESCRIPTION
* Move the liveness and readiness probes to a different port
* Default to `0` seconds if call the `/delay` endpoint without passing any variables