### PR TITLE
Add Proxy and AWS command

### DIFF
--- a/cmd/go-infrabin/main.go
+++ b/cmd/go-infrabin/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"os"
 	"os/signal"
 
@@ -14,16 +15,27 @@ func main() {
 	// SIGKILL, SIGQUIT or SIGTERM (Ctrl+/) will not be caught.
 	signal.Notify(finish, os.Interrupt)
 
+	// Make config
+	config := &infrabin.Config{}
+
+	flag.BoolVar(
+		&config.EnableProxyEndpoint,
+		"enable-proxy-endpoint",
+		false,
+		"If true, enables proxy and aws endpoints",
+	)
+	flag.Parse()
+
 	// run service server in background
-	server := infrabin.NewHTTPServer()
+	server := infrabin.NewHTTPServer(config)
 	go server.ListenAndServe()
 
 	// run admin server in background
-	admin := infrabin.NewAdminServer()
+	admin := infrabin.NewAdminServer(config)
 	go admin.ListenAndServe()
 
 	// run grpc server in background
-	grpcServer := infrabin.NewGRPCServer()
+	grpcServer := infrabin.NewGRPCServer(config)
 	go grpcServer.ListenAndServe()
 
 	// wait for SIGINT

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.13
 require (
 	github.com/golang/protobuf v1.4.1
 	github.com/gorilla/mux v1.7.3
-	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013
 	google.golang.org/grpc v1.30.0
 	google.golang.org/protobuf v1.25.0
 )

--- a/pkg/infrabin/config.go
+++ b/pkg/infrabin/config.go
@@ -1,0 +1,5 @@
+package infrabin
+
+type Config struct{
+	EnableProxyEndpoint bool
+}

--- a/pkg/infrabin/grpc.go
+++ b/pkg/infrabin/grpc.go
@@ -11,6 +11,7 @@ import (
 // Server wraps the gRPC server and implements infrabin.Infrabin
 type GRPCServer struct {
 	Name   string
+	Config *Config
 	Server *grpc.Server
 }
 
@@ -34,10 +35,10 @@ func (s *GRPCServer) Shutdown() {
 }
 
 // New creates a new rpc server.
-func NewGRPCServer() *GRPCServer {
+func NewGRPCServer(config *Config) *GRPCServer {
 	gs := grpc.NewServer()
-	s := &GRPCServer{Name: "grpc", Server: gs}
-	is := &InfrabinService{}
+	s := &GRPCServer{Name: "grpc", Config: config, Server: gs}
+	is := &InfrabinService{Config: config}
 	RegisterInfrabinServer(gs, is)
 	reflection.Register(gs)
 	return s

--- a/pkg/infrabin/http.go
+++ b/pkg/infrabin/http.go
@@ -6,16 +6,16 @@ import (
 	"io"
 	"log"
 	"net/http"
-	"net/textproto"
-	"strconv"
 	"time"
 
 	"github.com/gorilla/mux"
 	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
-type GRPCHandlerFunc func(ctx context.Context, request interface{}) (*Response, error)
-type RequestBuilder func(*http.Request) (interface{}, error)
+type GRPCHandlerFunc func(ctx context.Context, request interface{}) (proto.Message, error)
+type RequestBuilder func(*http.Request) (proto.Message, error)
 
 //func(context.Content, interface{}) (interface{}, error)
 func MakeHandler(grpcHandler GRPCHandlerFunc, requestBuilder RequestBuilder) http.HandlerFunc {
@@ -24,7 +24,7 @@ func MakeHandler(grpcHandler GRPCHandlerFunc, requestBuilder RequestBuilder) htt
 		w.Header().Set("Content-Type", "application/json")
 
 		var (
-			response *Response
+			response proto.Message
 			err      error
 		)
 		request, err := requestBuilder(r)
@@ -34,7 +34,26 @@ func MakeHandler(grpcHandler GRPCHandlerFunc, requestBuilder RequestBuilder) htt
 		} else {
 			response, err = grpcHandler(r.Context(), request)
 			if err != nil {
+				log.Printf("Error from grpcHandler: %v", err)
 				w.WriteHeader(http.StatusServiceUnavailable)
+				// If the response is of Type Response we can add Error
+				if resp, ok := response.(*Response); ok {
+					if resp == nil {
+						resp = &Response{}
+					}
+					resp.Error = fmt.Sprintf("Error from grpcHandler: %v", err)
+					response = resp
+				}
+				// If the response is of Type Struct we can add Error
+				if resp, ok := response.(*structpb.Struct); ok {
+					if resp == nil {
+						resp = &structpb.Struct{Fields: make(map[string]*structpb.Value)}
+					}
+					resp.Fields["error"] = structpb.NewStringValue(
+						fmt.Sprintf("Error from grpcHandler: %v", err),
+					)
+					response = resp
+				}
 			} else {
 				w.WriteHeader(http.StatusOK)
 			}
@@ -78,51 +97,46 @@ func NewHTTPServer() *HTTPServer {
 	is := InfrabinService{}
 
 	r.HandleFunc("/", MakeHandler(
-		func(ctx context.Context, req interface{}) (*Response, error) {
+		func(ctx context.Context, req interface{}) (proto.Message, error) {
 			return is.Root(ctx, req.(*Empty))
 		},
-		func(r *http.Request) (interface{}, error) {
-			return &Empty{}, nil
-		},
+		BuildEmpty,
 	)).Name("Root")
 
 	r.HandleFunc("/delay/{seconds}", MakeHandler(
-		func(ctx context.Context, req interface{}) (*Response, error) {
+		func(ctx context.Context, req interface{}) (proto.Message, error) {
 			return is.Delay(ctx, req.(*DelayRequest))
 		},
-		func(request *http.Request) (i interface{}, e error) {
-			vars := mux.Vars(request)
-			if seconds, err := strconv.Atoi(vars["seconds"]); err != nil {
-				return nil, err
-			} else {
-				return &DelayRequest{Duration: int32(seconds)}, nil
-			}
-		},
+		BuildDelayRequest,
 	)).Name("Delay")
 
 	r.HandleFunc("/env/{env_var}", MakeHandler(
-		func(ctx context.Context, req interface{}) (*Response, error) {
+		func(ctx context.Context, req interface{}) (proto.Message, error) {
 			return is.Env(ctx, req.(*EnvRequest))
 		},
-		func(request *http.Request) (i interface{}, e error) {
-			vars := mux.Vars(request)
-			return &EnvRequest{EnvVar: vars["env_var"]}, nil
-		},
+		BuildEnvRequest,
 	)).Name("Env")
 
 	r.HandleFunc("/headers", MakeHandler(
-		func(ctx context.Context, request interface{}) (*Response, error) {
+		func(ctx context.Context, request interface{}) (proto.Message, error) {
 			return is.Headers(ctx, request.(*HeadersRequest))
 		},
-		func(request *http.Request) (i interface{}, e error) {
-			inputHeaders := textproto.MIMEHeader(request.Header)
-			headers := make(map[string]string)
-			for key := range inputHeaders {
-				headers[key] = inputHeaders.Get(key)
-			}
-			return &HeadersRequest{Headers: headers}, nil
-		},
+		BuildHeadersRequest,
 	)).Name("Headers")
+
+	r.HandleFunc("/proxy", MakeHandler(
+		func(ctx context.Context, request interface{}) (proto.Message, error) {
+			return is.Proxy(ctx, request.(*ProxyRequest))
+		},
+		BuildProxyRequest,
+	)).Methods("POST").Name("Proxy")
+
+	r.HandleFunc("/aws/{path}", MakeHandler(
+		func(ctx context.Context, request interface{}) (proto.Message, error) {
+			return is.AWS(ctx, request.(*AWSRequest))
+		},
+		BuildAWSRequest,
+	)).Name("AWS")
 
 	server := &http.Server{
 		Handler: r,
@@ -139,12 +153,10 @@ func NewAdminServer() *HTTPServer {
 	is := InfrabinService{}
 
 	r.HandleFunc("/liveness", MakeHandler(
-		func(ctx context.Context, req interface{}) (*Response, error) {
+		func(ctx context.Context, req interface{}) (proto.Message, error) {
 			return is.Liveness(ctx, req.(*Empty))
 		},
-		func(request *http.Request) (i interface{}, e error) {
-			return &Empty{}, nil
-		},
+		BuildEmpty,
 	)).Name("Liveness")
 
 	server := &http.Server{

--- a/pkg/infrabin/http.go
+++ b/pkg/infrabin/http.go
@@ -70,6 +70,7 @@ func MakeHandler(grpcHandler GRPCHandlerFunc, requestBuilder RequestBuilder) htt
 
 type HTTPServer struct {
 	Name   string
+	Config *Config
 	Server *http.Server
 }
 
@@ -92,9 +93,9 @@ func (s *HTTPServer) Shutdown() {
 	}
 }
 
-func NewHTTPServer() *HTTPServer {
+func NewHTTPServer(config *Config) *HTTPServer {
 	r := mux.NewRouter()
-	is := InfrabinService{}
+	is := InfrabinService{config}
 
 	r.HandleFunc("/", MakeHandler(
 		func(ctx context.Context, req interface{}) (proto.Message, error) {
@@ -145,10 +146,10 @@ func NewHTTPServer() *HTTPServer {
 		WriteTimeout: 15 * time.Second,
 		ReadTimeout:  15 * time.Second,
 	}
-	return &HTTPServer{Name: "service", Server: server}
+	return &HTTPServer{Name: "service", Config: config, Server: server}
 }
 
-func NewAdminServer() *HTTPServer {
+func NewAdminServer(config *Config) *HTTPServer {
 	r := mux.NewRouter()
 	is := InfrabinService{}
 
@@ -167,5 +168,5 @@ func NewAdminServer() *HTTPServer {
 		ReadTimeout:  15 * time.Second,
 	}
 
-	return &HTTPServer{Name: "admin", Server: server}
+	return &HTTPServer{Name: "admin", Config: config, Server: server}
 }

--- a/pkg/infrabin/http_test.go
+++ b/pkg/infrabin/http_test.go
@@ -1,13 +1,14 @@
 package infrabin
 
 import (
-	"github.com/gorilla/mux"
-	"github.com/maruina/go-infrabin/internal/helpers"
-	"google.golang.org/protobuf/encoding/protojson"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/maruina/go-infrabin/internal/helpers"
+	"google.golang.org/protobuf/encoding/protojson"
 )
 
 func TestRootHandler(t *testing.T) {

--- a/pkg/infrabin/http_test.go
+++ b/pkg/infrabin/http_test.go
@@ -17,7 +17,7 @@ func TestRootHandler(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	rootHandler := NewHTTPServer().Server.Handler.(*mux.Router).Get("Root").GetHandler().ServeHTTP
+	rootHandler := NewHTTPServer(&Config{}).Server.Handler.(*mux.Router).Get("Root").GetHandler().ServeHTTP
 	rr := httptest.NewRecorder()
 	handler := http.HandlerFunc(rootHandler)
 	handler.ServeHTTP(rr, req)
@@ -56,7 +56,7 @@ func TestFailRootHandler(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	rootHandler := NewHTTPServer().Server.Handler.(*mux.Router).Get("Root").GetHandler().ServeHTTP
+	rootHandler := NewHTTPServer(&Config{}).Server.Handler.(*mux.Router).Get("Root").GetHandler().ServeHTTP
 	rr := httptest.NewRecorder()
 	handler := http.HandlerFunc(rootHandler)
 	handler.ServeHTTP(rr, req)
@@ -86,7 +86,7 @@ func TestRootHandlerKubernetes(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	rootHandler := NewHTTPServer().Server.Handler.(*mux.Router).Get("Root").GetHandler().ServeHTTP
+	rootHandler := NewHTTPServer(&Config{}).Server.Handler.(*mux.Router).Get("Root").GetHandler().ServeHTTP
 	rr := httptest.NewRecorder()
 	handler := http.HandlerFunc(rootHandler)
 	handler.ServeHTTP(rr, req)
@@ -123,7 +123,7 @@ func TestLivenessHandler(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	livenessHandler := NewAdminServer().Server.Handler.(*mux.Router).Get("Liveness").GetHandler().ServeHTTP
+	livenessHandler := NewAdminServer(&Config{}).Server.Handler.(*mux.Router).Get("Liveness").GetHandler().ServeHTTP
 	rr := httptest.NewRecorder()
 	handler := http.HandlerFunc(livenessHandler)
 	handler.ServeHTTP(rr, req)
@@ -150,7 +150,7 @@ func TestDelayHandler(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	delayHandler := NewHTTPServer().Server.Handler.(*mux.Router).Get("Delay").GetHandler().ServeHTTP
+	delayHandler := NewHTTPServer(&Config{}).Server.Handler.(*mux.Router).Get("Delay").GetHandler().ServeHTTP
 	rr := httptest.NewRecorder()
 	handler := http.HandlerFunc(delayHandler)
 	handler.ServeHTTP(rr, req)
@@ -176,7 +176,7 @@ func TestDelayHandlerBadRequest(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	delayHandler := NewHTTPServer().Server.Handler.(*mux.Router).Get("Delay").GetHandler().ServeHTTP
+	delayHandler := NewHTTPServer(&Config{}).Server.Handler.(*mux.Router).Get("Delay").GetHandler().ServeHTTP
 	rr := httptest.NewRecorder()
 	handler := http.HandlerFunc(delayHandler)
 	handler.ServeHTTP(rr, req)
@@ -202,7 +202,7 @@ func TestHeadersHandler(t *testing.T) {
 	}
 	req.Header.Set("X-Request-Id", "Test-Header")
 
-	headersHandler := NewHTTPServer().Server.Handler.(*mux.Router).Get("Headers").GetHandler().ServeHTTP
+	headersHandler := NewHTTPServer(&Config{}).Server.Handler.(*mux.Router).Get("Headers").GetHandler().ServeHTTP
 	rr := httptest.NewRecorder()
 	handler := http.HandlerFunc(headersHandler)
 	handler.ServeHTTP(rr, req)
@@ -232,7 +232,7 @@ func TestEnvHandler(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	envHandler := NewHTTPServer().Server.Handler.(*mux.Router).Get("Env").GetHandler().ServeHTTP
+	envHandler := NewHTTPServer(&Config{}).Server.Handler.(*mux.Router).Get("Env").GetHandler().ServeHTTP
 	rr := httptest.NewRecorder()
 	handler := http.HandlerFunc(envHandler)
 	handler.ServeHTTP(rr, req)
@@ -259,7 +259,7 @@ func TestEnvHandlerNotFound(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	envHandler := NewHTTPServer().Server.Handler.(*mux.Router).Get("Env").GetHandler().ServeHTTP
+	envHandler := NewHTTPServer(&Config{}).Server.Handler.(*mux.Router).Get("Env").GetHandler().ServeHTTP
 	rr := httptest.NewRecorder()
 	handler := http.HandlerFunc(envHandler)
 	handler.ServeHTTP(rr, req)

--- a/pkg/infrabin/infrabin.go
+++ b/pkg/infrabin/infrabin.go
@@ -22,7 +22,9 @@ import (
 
 const AWS_METADATA_ENDPOINT = "http://169.254.169.254/latest/meta-data/"
 
-type InfrabinService struct{}
+type InfrabinService struct{
+	Config *Config
+}
 
 func (s *InfrabinService) Root(ctx context.Context, _ *Empty) (*Response, error) {
 	fail := helpers.GetEnv("FAIL_ROOT_HANDLER", "")
@@ -84,6 +86,9 @@ func (s *InfrabinService) Headers(ctx context.Context, request *HeadersRequest) 
 }
 
 func (s *InfrabinService) Proxy(ctx context.Context, request *ProxyRequest) (*structpb.Struct, error) {
+	if !s.Config.EnableProxyEndpoint {
+		return nil, status.Errorf(codes.Unimplemented, "Proxy endpoint disabled. Enabled with --enable-proxy-endpoint")
+	}
 	// Convert Struct into json []byte
 	requestBody, err := request.Body.MarshalJSON()
 	if err != nil {

--- a/pkg/infrabin/infrabin.go
+++ b/pkg/infrabin/infrabin.go
@@ -11,6 +11,7 @@ import (
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	_struct "github.com/golang/protobuf/ptypes/struct"
 
 	"github.com/maruina/go-infrabin/internal/helpers"
 )
@@ -74,4 +75,8 @@ func (s *InfrabinService) Headers(ctx context.Context, request *HeadersRequest) 
 		request.Headers[key] = strings.Join(md.Get(key), ",")
 	}
 	return &Response{Headers: request.Headers}, nil
+}
+
+func (s *InfrabinService) AWS(ctx context.Context, request *_struct.Struct) (*_struct.Struct, error) {
+	return request, nil
 }

--- a/pkg/infrabin/infrabin_test.go
+++ b/pkg/infrabin/infrabin_test.go
@@ -1,0 +1,1 @@
+package infrabin

--- a/pkg/infrabin/requestbuilders.go
+++ b/pkg/infrabin/requestbuilders.go
@@ -17,6 +17,29 @@ func BuildEmpty(r *http.Request) (proto.Message, error) {
 	return &Empty{}, nil
 }
 
+func BuildDelayRequest(request *http.Request) (proto.Message, error) {
+	vars := mux.Vars(request)
+	if seconds, err := strconv.Atoi(vars["seconds"]); err != nil {
+		return nil, err
+	} else {
+		return &DelayRequest{Duration: int32(seconds)}, nil
+	}
+}
+
+func BuildEnvRequest(request *http.Request) (proto.Message, error) {
+	vars := mux.Vars(request)
+	return &EnvRequest{EnvVar: vars["env_var"]}, nil
+}
+
+func BuildHeadersRequest(request *http.Request) (proto.Message, error) {
+	inputHeaders := textproto.MIMEHeader(request.Header)
+	headers := make(map[string]string)
+	for key := range inputHeaders {
+		headers[key] = inputHeaders.Get(key)
+	}
+	return &HeadersRequest{Headers: headers}, nil
+}
+
 func BuildProxyRequest(request *http.Request) (proto.Message, error) {
 	// Read request body
 	inputBody, err := ioutil.ReadAll(request.Body)
@@ -43,29 +66,6 @@ func BuildProxyRequest(request *http.Request) (proto.Message, error) {
 		Headers: headers,
 	}
 	return proxyRequest, nil
-}
-
-func BuildHeadersRequest(request *http.Request) (proto.Message, error) {
-	inputHeaders := textproto.MIMEHeader(request.Header)
-	headers := make(map[string]string)
-	for key := range inputHeaders {
-		headers[key] = inputHeaders.Get(key)
-	}
-	return &HeadersRequest{Headers: headers}, nil
-}
-
-func BuildEnvRequest(request *http.Request) (proto.Message, error) {
-	vars := mux.Vars(request)
-	return &EnvRequest{EnvVar: vars["env_var"]}, nil
-}
-
-func BuildDelayRequest(request *http.Request) (proto.Message, error) {
-	vars := mux.Vars(request)
-	if seconds, err := strconv.Atoi(vars["seconds"]); err != nil {
-		return nil, err
-	} else {
-		return &DelayRequest{Duration: int32(seconds)}, nil
-	}
 }
 
 func BuildAWSRequest(request *http.Request) (proto.Message, error) {

--- a/pkg/infrabin/requestbuilders.go
+++ b/pkg/infrabin/requestbuilders.go
@@ -1,0 +1,74 @@
+package infrabin
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/textproto"
+	"strconv"
+
+	"github.com/gorilla/mux"
+
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+func BuildEmpty(r *http.Request) (proto.Message, error) {
+	return &Empty{}, nil
+}
+
+func BuildProxyRequest(request *http.Request) (proto.Message, error) {
+	// Read request body
+	inputBody, err := ioutil.ReadAll(request.Body)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to read body: %v", err)
+	}
+
+	// Create Struct
+	var body structpb.Struct
+	if err := body.UnmarshalJSON(inputBody); err != nil {
+		return nil, fmt.Errorf("Failed to unmarshal body json: %v", err)
+	}
+
+	// Make map[string]string headers
+	headers := make(map[string]string)
+	for key, value := range body.Fields["headers"].GetStructValue().AsMap() {
+		headers[key] = fmt.Sprintf("%s", value)
+	}
+
+	proxyRequest := &ProxyRequest{
+		Method:  body.Fields["method"].GetStringValue(),
+		Url:     body.Fields["url"].GetStringValue(),
+		Body:    body.Fields["body"].GetStructValue(),
+		Headers: headers,
+	}
+	return proxyRequest, nil
+}
+
+func BuildHeadersRequest(request *http.Request) (proto.Message, error) {
+	inputHeaders := textproto.MIMEHeader(request.Header)
+	headers := make(map[string]string)
+	for key := range inputHeaders {
+		headers[key] = inputHeaders.Get(key)
+	}
+	return &HeadersRequest{Headers: headers}, nil
+}
+
+func BuildEnvRequest(request *http.Request) (proto.Message, error) {
+	vars := mux.Vars(request)
+	return &EnvRequest{EnvVar: vars["env_var"]}, nil
+}
+
+func BuildDelayRequest(request *http.Request) (proto.Message, error) {
+	vars := mux.Vars(request)
+	if seconds, err := strconv.Atoi(vars["seconds"]); err != nil {
+		return nil, err
+	} else {
+		return &DelayRequest{Duration: int32(seconds)}, nil
+	}
+}
+
+func BuildAWSRequest(request *http.Request) (proto.Message, error) {
+	vars := mux.Vars(request)
+	return &AWSRequest{Path: vars["path"]}, nil
+}

--- a/pkg/infrabin/requestbuilders_test.go
+++ b/pkg/infrabin/requestbuilders_test.go
@@ -1,0 +1,115 @@
+package infrabin
+
+import (
+	"bytes"
+	"encoding/json"
+	"github.com/gorilla/mux"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/structpb"
+	"net/http"
+	"testing"
+)
+
+func makeRequestBody(t testing.TB, j map[string]interface{}) *bytes.Buffer{
+	b, err := json.Marshal(j)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return bytes.NewBuffer(b)
+}
+
+func TestBuildEmpty(t *testing.T) {
+	request, err := http.NewRequest("GET", "/", nil)
+	if err != nil {
+		t.Fatalf("Failed to build http.Request: %v", err)
+	}
+
+	expected := &Empty{}
+
+	if msg, err := BuildEmpty(request); err != nil {
+		t.Errorf("BuildEmpty returned an error, %v", err)
+	} else if !proto.Equal(msg, expected) {
+		t.Errorf("Expected %v got %v", expected, msg)
+	}
+}
+
+
+func TestBuildEnvRequest(t *testing.T) {
+	request, err := http.NewRequest("GET", "/env", nil)
+	if err != nil {
+		t.Fatalf("Failed to build http.Request: %v", err)
+	}
+	request = mux.SetURLVars(request, map[string]string{"env_var": "TEST_ENV"})
+
+	expected := &EnvRequest{EnvVar: "TEST_ENV"}
+
+	if msg, err := BuildEnvRequest(request); err != nil {
+		t.Errorf("BuildEnvRequest returned an error, %v", err)
+	} else if !proto.Equal(msg, expected) {
+		t.Errorf("Expected %v got %v", expected, msg)
+	}
+}
+
+
+func TestBuildHeadersRequest(t *testing.T) {
+	request, err := http.NewRequest("GET", "/headers", nil)
+	if err != nil {
+		t.Fatalf("Failed to build http.Request: %v", err)
+	}
+	request.Header.Set("X-Request-Id", "Test-Header")
+
+	expected := &HeadersRequest{Headers: map[string]string{"X-Request-Id": "Test-Header"}}
+
+	if msg, err := BuildHeadersRequest(request); err != nil {
+		t.Errorf("BuildHeadersRequest returned an error, %v", err)
+	} else if !proto.Equal(msg, expected) {
+		t.Errorf("Expected %v got %v", expected, msg)
+	}
+}
+
+
+func TestBuildProxyRequest(t *testing.T) {
+	body := makeRequestBody(t, map[string]interface{}{
+		"method": "POST",
+		"url": "http://httpbin.org/post",
+		"body": map[string]string{"a": "b"},
+		"headers": map[string]string{"X-Request-Id": "Test-Header"},
+	})
+	request, err := http.NewRequest("GET", "/proxy", body)
+	if err != nil {
+		t.Fatalf("Failed to build http.Request: %v", err)
+	}
+
+	structBody, err := structpb.NewStruct(map[string]interface{}{"a": "b"})
+	if err != nil {
+		t.Fatalf("Failed to create Struct: %v", err)
+	}
+	expected := &ProxyRequest{
+		Method: "POST",
+		Url: "http://httpbin.org/post",
+		Body: structBody,
+		Headers: map[string]string{"X-Request-Id": "Test-Header"},
+	}
+
+	if msg, err := BuildProxyRequest(request); err != nil {
+		t.Errorf("BuildProxyRequest returned an error, %v", err)
+	} else if !proto.Equal(msg, expected) {
+		t.Errorf("Expected %v got %v", expected, msg)
+	}
+}
+
+func TestBuildAWSRequest(t *testing.T) {
+	request, err := http.NewRequest("GET", "/aws", nil)
+	if err != nil {
+		t.Fatalf("Failed to build http.Request: %v", err)
+	}
+	request = mux.SetURLVars(request, map[string]string{"path": "foo/bar"})
+
+	expected := &AWSRequest{Path: "foo/bar"}
+
+	if msg, err := BuildAWSRequest(request); err != nil {
+		t.Errorf("BuildAWSRequest returned an error, %v", err)
+	} else if !proto.Equal(msg, expected) {
+		t.Errorf("Expected %v got %v", expected, msg)
+	}
+}

--- a/proto/infrabin.proto
+++ b/proto/infrabin.proto
@@ -42,6 +42,17 @@ message HeadersRequest {
     map<string, string> headers = 1;
 }
 
+message ProxyRequest {
+    string method = 1;
+    string url = 2;
+    google.protobuf.Struct body = 3;
+    map<string, string> headers = 4;
+}
+
+message AWSRequest {
+    string path = 1;
+}
+
 
 // The echo infrabin service replies with the message it received.
 service Infrabin {
@@ -50,5 +61,6 @@ service Infrabin {
   rpc Liveness(Empty) returns (Response) {}
   rpc Env(EnvRequest) returns (Response) {}
   rpc Headers(HeadersRequest) returns (Response) {}
-  rpc AWS(google.protobuf.Struct) returns (google.protobuf.Struct) {}
+  rpc Proxy(ProxyRequest) returns (google.protobuf.Struct) {}
+  rpc AWS(AWSRequest) returns (google.protobuf.Struct) {}
 }

--- a/proto/infrabin.proto
+++ b/proto/infrabin.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package infrabin;
 
+import "google/protobuf/struct.proto";
+
 option go_package = "github.com/maruina/go-infrabin/pkg/infrabin;infrabin";
 
 // Empty is the null value for parameters.
@@ -48,4 +50,5 @@ service Infrabin {
   rpc Liveness(Empty) returns (Response) {}
   rpc Env(EnvRequest) returns (Response) {}
   rpc Headers(HeadersRequest) returns (Response) {}
+  rpc AWS(google.protobuf.Struct) returns (google.protobuf.Struct) {}
 }


### PR DESCRIPTION
# Summary

- Add `Config` which is passed to each server and grpc implementation
- Add AWS command which proxies GET commands to the underlying instance metadata API
- Add Proxy command which proxies any HTTP request and returns response
- Add `--enable-proxy-endpoint` flag which is `false` by default. This is because running with Proxy and AWS in prod is a bad idea.
- Move RequestBuilders in http.go to own file

## Notes on requestbuilders.go

- Each gRPC request type has a function to map between a http.Request the Proto
- I added tests for these as they were starting to get quite large
- It required a change to the `MakeHandler` function

## How much longer do we write `http.go`?

- I will play with grpc-gateway as from this PR, I have gotten a bit fed up maintaining the mapping http to grpc code and it has been 1 day.
