### PR TITLE
Add envoy-preflight

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,14 @@ RUN apt-get update && \
     mv protoc/bin/protoc /usr/local/bin/ && \
     go get github.com/golang/protobuf/protoc-gen-go && \
     curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.27.0
+RUN wget -O /envoy-preflight https://github.com/monzo/envoy-preflight/releases/download/v1.0/envoy-preflight && \
+    chmod +x /envoy-preflight
 WORKDIR /go/src/go-infrabin
 COPY . /go/src/go-infrabin
 RUN make build && make test
 
+
 FROM gcr.io/distroless/base-debian10
 COPY --from=builder /go/src/go-infrabin/go-infrabin /usr/local/bin/go-infrabin
-ENTRYPOINT [ "/usr/local/bin/go-infrabin" ]
+COPY --from=builder /envoy-preflight /envoy-preflight
+ENTRYPOINT [ "/envoy-preflight", "/usr/local/bin/go-infrabin" ]


### PR DESCRIPTION
# Summary

Downloading the precompiled binary for `envoy-preflight`
I have not included a wrapper entrypoint like in the python version. So `USE_ENVOY_PREFLIGHT` is ignored. Instead, the presence of `ENVOY_ADMIN_API` means it will be used.
