### PR TITLE
Ignore infrabin.pb.go for coverage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,18 +22,20 @@ jobs:
     - name: Check out code
       uses: actions/checkout@v2
 
-    - name: Genereate code for infrabin protofile
-      uses: squzy/protoc-actions@v2.0.9
-      with:
-        path: --proto_path=proto/ --go_out=plugins=grpc:pkg/infrabin --go_opt=paths=source_relative proto/infrabin.proto
+    - name: Install Protoc
+      uses: arduino/setup-protoc@master
 
     - name: Get dependencies
       run: |
+        go get -u github.com/golang/protobuf/protoc-gen-go
         go get -v -t -d ./...
         if [ -f Gopkg.toml ]; then
             curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
             dep ensure
         fi
+
+    - name: Genereate code for infrabin protofile
+      run: make protoc
 
     - name: Run golangci-lint
       uses: golangci/golangci-lint-action@v0.2.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,17 +46,12 @@ jobs:
     - name: Test
       run: go test -v -covermode=atomic -coverprofile=coverage.out -race ./...
 
-    - name: Convert coverage to lcov
-      uses: jandelgado/gcov2lcov-action@v1.0.2
-      with:
-          infile: coverage.out
-          outfile: coverage.lcov
-
-    - name: Coveralls GitHub Action
-      uses: coverallsapp/github-action@v1.1.1
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        path-to-lcov: coverage.lcov
+    - name: Send coverage
+      env:
+        COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        GO111MODULE=off go get github.com/mattn/goveralls
+        $(go env GOPATH)/bin/goveralls -coverprofile=coverage.out -service=github -ignore=pkg/infrabin/infrabin.pb.go
 
     - name: Build docker image on PR
       uses: docker/build-push-action@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,11 +49,10 @@ jobs:
       run: go test -v -covermode=atomic -coverprofile=coverage.out -race ./...
 
     - name: Send coverage
-      env:
-        COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        GO111MODULE=off go get github.com/mattn/goveralls
-        $(go env GOPATH)/bin/goveralls -coverprofile=coverage.out -service=github -ignore=pkg/infrabin/infrabin.pb.go
+      uses: shogo82148/actions-goveralls@v1
+      with:
+        path-to-profile: coverage.out
+        ignore: pkg/infrabin/infrabin.pb.go
 
     - name: Build docker image on PR
       uses: docker/build-push-action@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,10 +22,14 @@ jobs:
     - name: Unshallow
       run: git fetch --prune --unshallow
 
+    - name: Install Protoc
+      uses: arduino/setup-protoc@master
+
+    - name: Get protoc-gen-go
+      run: go get -u github.com/golang/protobuf/protoc-gen-go
+
     - name: Genereate code for infrabin protofile
-      uses: squzy/protoc-actions@v2.0.9
-      with:
-        path: --proto_path=proto/ --go_out=plugins=grpc:pkg/infrabin --go_opt=paths=source_relative proto/infrabin.proto
+      run: make protoc
 
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v1
@@ -35,3 +39,11 @@ jobs:
         key: ${{ secrets.YOUR_PRIVATE_KEY }}
       env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build and push tagged docker image on master
+      uses: docker/build-push-action@v1
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        repository: maruina/go-infrabin
+        tags: ${{ github.event.release.tag_name }}


### PR DESCRIPTION
New action coming from https://github.com/mattn/goveralls#github-actions, so we can

- ignore `infrabin.pb.go`
- remove one step