### PR TITLE
Fix dependencies installation steps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,9 +24,11 @@ jobs:
     - name: Install Protoc
       uses: arduino/setup-protoc@master
 
+    - name: Get dependencies
+      run: go get -t -v -d ./...
+
     - name: Get protoc go binaries
       run: |
-        go mod tidy
         go install \
           github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway \
           github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2 \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,9 +27,11 @@ jobs:
     - name: Install Protoc
       uses: arduino/setup-protoc@master
 
+    - name: Get dependencies
+      run: go get -t -v -d ./...
+
     - name: Get protoc go binaries
       run: |
-        go mod tidy
         go install \
           github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway \
           github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN wget -O /envoy-preflight https://github.com/monzo/envoy-preflight/releases/d
     chmod +x /envoy-preflight
 WORKDIR /go/src/go-infrabin
 COPY . /go/src/go-infrabin
-RUN go mod tidy && \
+RUN go get -t -v -d ./... && \
     go install \
         github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway \
         github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2 \

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ test-ci:
 protoc:
 	protoc --proto_path=proto/ --go_out=pkg/infrabin --go_opt=paths=source_relative --go-grpc_out=pkg/infrabin --go-grpc_opt=paths=source_relative proto/infrabin.proto
 	protoc --proto_path=proto/ --grpc-gateway_out=logtostderr=true,paths=source_relative:pkg/infrabin proto/infrabin.proto
+	go mod tidy
 
 build: protoc
 	go build -o $(BINARY_NAME) cmd/$(BINARY_NAME)/main.go

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,6 @@ test-ci:
 protoc:
 	protoc --proto_path=proto/ --go_out=pkg/infrabin --go_opt=paths=source_relative --go-grpc_out=pkg/infrabin --go-grpc_opt=paths=source_relative proto/infrabin.proto
 	protoc --proto_path=proto/ --grpc-gateway_out=logtostderr=true,paths=source_relative:pkg/infrabin proto/infrabin.proto
-	go mod tidy
 
 build: protoc
 	go build -o $(BINARY_NAME) cmd/$(BINARY_NAME)/main.go

--- a/README.md
+++ b/README.md
@@ -118,10 +118,9 @@ See the [README](./chart/go-infrabin/README.md).
     * _returns_:
         JSON of AWS GET call
 
-
 ## Admin Endpoints
 
-* `GET /liveness`
+* _grpc_: `infrabin.Infrabin.Liveness` _rest_: `GET /liveness`
     * _grpc request_
         ```
         message Empty {}
@@ -145,19 +144,22 @@ have the following format:
     }
     ```
 
-
 ### Contributing
 
 To build locally, ensure you have compiled the protocol schemas. You
 will need the `protoc` binary which can install by following
-[these instructions][protoc].
+[these instructions][protoc] or if using Homebrew
+
+```shell
+brew install protobuf
+```
 
 You will also need to protoc go plugins for protofuf, grpc, and
 grpc-gateway. `go mod tidy` will fetch the versions specified in
 `go.mod`, and `go install` will install that version.
 
 ```shell
-go mod tidy
+go get -t -v -d ./...
 go install \
   github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway \
   github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2 \


### PR DESCRIPTION
Fix https://github.com/maruina/go-infrabin/actions/runs/159498382 by running `go mod tidy` from the master branch.