### PR TITLE
Add support for google.golang.org/grpc/health

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ go-infrabin
 pkg/infrabin/infrabin.pb.go
 pkg/infrabin/infrabin.pb.gw.go
 pkg/infrabin/infrabin_grpc.pb.go
+pkg/grpc/health/v1/health.pb.gw.go

--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,26 @@ test-ci:
 	${HOME}/gopath/bin/goveralls -coverprofile=coverage.out -service=travis-ci -repotoken ${COVERALLS_TOKEN}
 
 protoc:
-	protoc --proto_path=proto/ --go_out=pkg/infrabin --go_opt=paths=source_relative --go-grpc_out=pkg/infrabin --go-grpc_opt=paths=source_relative proto/infrabin.proto
-	protoc --proto_path=proto/ --grpc-gateway_out=logtostderr=true,paths=source_relative:pkg/infrabin proto/infrabin.proto
+	protoc \
+	    --proto_path=proto/ \
+	    --go_out=paths=source_relative:pkg \
+	    --go-grpc_out=paths=source_relative:pkg \
+	    --grpc-gateway_out=logtostderr=true,paths=source_relative:pkg \
+	    proto/infrabin/infrabin.proto
+	protoc \
+		--proto_path=proto/ \
+		--grpc-gateway_out=logtostderr=true,paths=source_relative,standalone=true:pkg \
+		proto/grpc/health/v1/health.proto
+	sed \
+		-i '' \
+		-e 's/PopulateQueryParameters(&protoReq/PopulateQueryParameters(protov1.MessageV2(\&protoReq)/g' \
+		-e 's/msg, metadata, err/protov1.MessageV2(msg), metadata, err/g' \
+		pkg/grpc/health/v1/health.pb.gw.go
+	mv pkg/grpc/health/v1/health.pb.gw.go pkg/grpc/health/v1/health.pb.gw.go.bak
+	head -n 23 pkg/grpc/health/v1/health.pb.gw.go.bak > pkg/grpc/health/v1/health.pb.gw.go
+	echo '    protov1 "github.com/golang/protobuf/proto"' >> pkg/grpc/health/v1/health.pb.gw.go
+	tail -n +24 pkg/grpc/health/v1/health.pb.gw.go.bak >> pkg/grpc/health/v1/health.pb.gw.go
+	rm pkg/grpc/health/v1/health.pb.gw.go.bak
 
 build: protoc
 	go build -o $(BINARY_NAME) cmd/$(BINARY_NAME)/main.go

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ protoc:
 		--proto_path=proto/ \
 		--grpc-gateway_out=logtostderr=true,paths=source_relative,standalone=true:pkg \
 		proto/grpc/health/v1/health.proto
+	ls -R pkg
 	sed \
 		-i '' \
 		-e 's/PopulateQueryParameters(&protoReq/PopulateQueryParameters(protov1.MessageV2(\&protoReq)/g' \

--- a/Makefile
+++ b/Makefile
@@ -23,9 +23,8 @@ protoc:
 		--proto_path=proto/ \
 		--grpc-gateway_out=logtostderr=true,paths=source_relative,standalone=true:pkg \
 		proto/grpc/health/v1/health.proto
-	ls -R pkg
 	sed \
-		-i '' \
+		-i.bak \
 		-e 's/PopulateQueryParameters(&protoReq/PopulateQueryParameters(protov1.MessageV2(\&protoReq)/g' \
 		-e 's/msg, metadata, err/protov1.MessageV2(msg), metadata, err/g' \
 		pkg/grpc/health/v1/health.pb.gw.go

--- a/cmd/go-infrabin/main.go
+++ b/cmd/go-infrabin/main.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"os/signal"
 
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+
 	"github.com/maruina/go-infrabin/pkg/infrabin"
 )
 
@@ -34,7 +36,7 @@ func main() {
 	server := infrabin.NewHTTPServer(
 		"server",
 		"0.0.0.0:8888",
-		infrabin.RegisterInfrabin(grpcServer.InfrabinService),
+		infrabin.RegisterInfrabin("/", grpcServer.InfrabinService),
 	)
 	go server.ListenAndServe()
 
@@ -42,12 +44,17 @@ func main() {
 	admin := infrabin.NewHTTPServer(
 		"admin",
 		"0.0.0.0:8899",
-		infrabin.RegisterHealth(grpcServer.HealthService),
+		infrabin.RegisterHealth("/healthcheck/liveness/", grpcServer.HealthService),
+		infrabin.RegisterHealth("/healthcheck/readiness/", grpcServer.HealthService),
 	)
 	go admin.ListenAndServe()
 
 	// run Prometheus server
-	promServer := infrabin.NewPromServer("prom", "0.0.0.0:8877", config)
+	promServer := infrabin.NewHTTPServer(
+		"prom",
+		"0.0.0.0:8877",
+		infrabin.RegisterHandler("/", promhttp.Handler()),
+	)
 	go promServer.ListenAndServe()
 
 	// wait for SIGINT

--- a/cmd/go-infrabin/main.go
+++ b/cmd/go-infrabin/main.go
@@ -26,17 +26,25 @@ func main() {
 	)
 	flag.Parse()
 
-	// run service server in background
-	server := infrabin.NewHTTPServer("server", "0.0.0.0:8888", config)
-	go server.ListenAndServe()
-
-	// run admin server in background
-	admin := infrabin.NewHTTPServer("admin", "0.0.0.0:8899", config)
-	go admin.ListenAndServe()
-
 	// run grpc server in background
 	grpcServer := infrabin.NewGRPCServer(config)
 	go grpcServer.ListenAndServe()
+
+	// run service server in background
+	server := infrabin.NewHTTPServer(
+		"server",
+		"0.0.0.0:8888",
+		infrabin.RegisterInfrabin(grpcServer.InfrabinService),
+	)
+	go server.ListenAndServe()
+
+	// run admin server in background
+	admin := infrabin.NewHTTPServer(
+		"admin",
+		"0.0.0.0:8899",
+		infrabin.RegisterHealth(grpcServer.HealthService),
+	)
+	go admin.ListenAndServe()
 
 	// run Prometheus server
 	promServer := infrabin.NewPromServer("prom", "0.0.0.0:8877", config)

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,7 @@ github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XL
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
@@ -63,8 +64,10 @@ github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
+github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
@@ -75,6 +78,7 @@ github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3Rllmb
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=
@@ -99,6 +103,7 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
@@ -172,12 +177,14 @@ google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlba
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.3 h1:fvjTMHxHEw/mxHbtzPi3JCcKXQRAnQTBRo6YCJSVHKI=
 gopkg.in/yaml.v2 v2.2.3/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.5 h1:ymVxjfMaHvXD8RqPRmzHHsB3VvucivSkIAvJFDI5O3c=
 gopkg.in/yaml.v2 v2.2.5/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/internal/helpers/tools.go
+++ b/internal/helpers/tools.go
@@ -5,6 +5,6 @@ package helpers
 import (
 	_ "github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway"
 	_ "github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2"
-	_ "google.golang.org/protobuf/cmd/protoc-gen-go"
 	_ "google.golang.org/grpc/cmd/protoc-gen-go-grpc"
+	_ "google.golang.org/protobuf/cmd/protoc-gen-go"
 )

--- a/pkg/infrabin/config.go
+++ b/pkg/infrabin/config.go
@@ -1,6 +1,6 @@
 package infrabin
 
-type Config struct{
+type Config struct {
 	EnableProxyEndpoint bool
 	AWSMetadataEndpoint string
 }

--- a/pkg/infrabin/grpc.go
+++ b/pkg/infrabin/grpc.go
@@ -4,11 +4,11 @@ import (
 	"log"
 	"net"
 
+	"github.com/grpc-ecosystem/go-grpc-prometheus"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/health"
 	"google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/reflection"
-	"github.com/grpc-ecosystem/go-grpc-prometheus"
 )
 
 // Server wraps the gRPC server and implements infrabin.Infrabin

--- a/pkg/infrabin/grpc.go
+++ b/pkg/infrabin/grpc.go
@@ -4,7 +4,7 @@ import (
 	"log"
 	"net"
 
-	"github.com/grpc-ecosystem/go-grpc-prometheus"
+	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/health"
 	"google.golang.org/grpc/health/grpc_health_v1"

--- a/pkg/infrabin/grpc.go
+++ b/pkg/infrabin/grpc.go
@@ -5,15 +5,19 @@ import (
 	"net"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/health"
+	"google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/reflection"
 	"github.com/grpc-ecosystem/go-grpc-prometheus"
 )
 
 // Server wraps the gRPC server and implements infrabin.Infrabin
 type GRPCServer struct {
-	Name   string
-	Config *Config
-	Server *grpc.Server
+	Name            string
+	Config          *Config
+	Server          *grpc.Server
+	InfrabinService InfrabinServer
+	HealthService   *health.Server
 }
 
 // ListenAndServe binds the server to the indicated interface:port.
@@ -30,9 +34,11 @@ func (s *GRPCServer) ListenAndServe() {
 }
 
 func (s *GRPCServer) Shutdown() {
+	log.Printf("Set all serving status to NOT_SERVING")
+	s.HealthService.Shutdown()
 	log.Printf("Shutting down %s server with GracefulStop()", s.Name)
 	s.Server.GracefulStop()
-	log.Printf("GRPC %s server stopped", s.Name)
+	log.Printf("gRPC %s server stopped", s.Name)
 }
 
 // New creates a new rpc server.
@@ -40,11 +46,26 @@ func NewGRPCServer(config *Config) *GRPCServer {
 	gs := grpc.NewServer(
 		grpc.StreamInterceptor(grpc_prometheus.StreamServerInterceptor),
 		grpc.UnaryInterceptor(grpc_prometheus.UnaryServerInterceptor),
-		)
-	s := &GRPCServer{Name: "grpc", Config: config, Server: gs}
-	is := &InfrabinService{Config: config}
-	RegisterInfrabinServer(gs, is)
-	reflection.Register(gs)
+	)
+
+	// Create the gPRC services
+	healthServer := health.NewServer()
+	infrabinService := &InfrabinService{Config: config}
+
+	// Register gRPC services on the grpc server
+	RegisterInfrabinServer(gs, infrabinService)
+	grpc_health_v1.RegisterHealthServer(gs, healthServer)
 	grpc_prometheus.Register(gs)
-	return s
+	reflection.Register(gs)
+
+	// Set the health of the infrabin service to healthy
+	healthServer.SetServingStatus("infrabin.Infrabin", grpc_health_v1.HealthCheckResponse_SERVING)
+
+	return &GRPCServer{
+		Name:            "grpc",
+		Config:          config,
+		Server:          gs,
+		InfrabinService: infrabinService,
+		HealthService:   healthServer,
+	}
 }

--- a/pkg/infrabin/http.go
+++ b/pkg/infrabin/http.go
@@ -104,12 +104,12 @@ func NewPromServer(name string, addr string, config *Config) *HTTPServer {
 	mux := http.NewServeMux()
 	mux.Handle("/metrics", promhttp.Handler())
 	promServer := &http.Server{
-		Addr: addr,
+		Addr:    addr,
 		Handler: mux,
 		// Good practice: enforce timeouts
-		WriteTimeout: 15 * time.Second,
-		ReadTimeout: 15 * time.Second,
-		IdleTimeout: 30 * time.Second,
+		WriteTimeout:      15 * time.Second,
+		ReadTimeout:       15 * time.Second,
+		IdleTimeout:       30 * time.Second,
 		ReadHeaderTimeout: 2 * time.Second,
 	}
 	return &HTTPServer{Name: name, Server: promServer}

--- a/pkg/infrabin/http.go
+++ b/pkg/infrabin/http.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/maruina/go-infrabin/pkg/grpc/health/v1"
+	grpc_health_v1 "github.com/maruina/go-infrabin/pkg/grpc/health/v1"
 	"google.golang.org/grpc/health"
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"

--- a/pkg/infrabin/http_test.go
+++ b/pkg/infrabin/http_test.go
@@ -3,14 +3,15 @@ package infrabin
 import (
 	"bytes"
 	"encoding/json"
-	"google.golang.org/grpc/health"
-	"google.golang.org/grpc/health/grpc_health_v1"
-	"google.golang.org/protobuf/runtime/protoimpl"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"reflect"
 	"testing"
+
+	"google.golang.org/grpc/health"
+	"google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/protobuf/runtime/protoimpl"
 
 	"github.com/maruina/go-infrabin/internal/helpers"
 	"google.golang.org/grpc/codes"

--- a/pkg/infrabin/http_test.go
+++ b/pkg/infrabin/http_test.go
@@ -3,14 +3,15 @@ package infrabin
 import (
 	"bytes"
 	"encoding/json"
-	"github.com/maruina/go-infrabin/internal/helpers"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"reflect"
 	"testing"
+
+	"github.com/maruina/go-infrabin/internal/helpers"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"google.golang.org/protobuf/encoding/protojson"
 )
@@ -188,9 +189,9 @@ func TestHeadersHandler(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	req.Header.Set("X-Request-Id", "Test-Header")  // Custom header
-	req.Header.Set("Accept", "*/*")  // Well known header
-	req.Header.Set("Grpc-Metadata-Foo", "bar")  // gRPC metadata
+	req.Header.Set("X-Request-Id", "Test-Header") // Custom header
+	req.Header.Set("Accept", "*/*")               // Well known header
+	req.Header.Set("Grpc-Metadata-Foo", "bar")    // gRPC metadata
 
 	rr := httptest.NewRecorder()
 	handler := NewHTTPServer("test", "", DefaultConfig()).Server.Handler
@@ -202,8 +203,8 @@ func TestHeadersHandler(t *testing.T) {
 
 	expected := Response{Headers: map[string]string{
 		"grpcgateway-x-request-id": "Test-Header",
-		"grpcgateway-accept": "*/*",
-		"foo": "bar",
+		"grpcgateway-accept":       "*/*",
+		"foo":                      "bar",
 	}}
 	marshalOptions := protojson.MarshalOptions{UseProtoNames: true}
 	data, _ := marshalOptions.Marshal(&expected)
@@ -268,10 +269,10 @@ func TestProxyHandler(t *testing.T) {
 	defer mockServer.Close()
 
 	body, err := json.Marshal(map[string]interface{}{
-		"method": "POST",
-		"url": mockServer.URL,
+		"method":  "POST",
+		"url":     mockServer.URL,
 		"headers": map[string]string{"Accept": "*/*"},
-		"body": map[string]string{},
+		"body":    map[string]string{},
 	})
 	if err != nil {
 		t.Fatalf("Failed to make request body: %v", err)
@@ -283,7 +284,7 @@ func TestProxyHandler(t *testing.T) {
 	}
 
 	rr := httptest.NewRecorder()
-	handler := NewHTTPServer("test", "",  &Config{EnableProxyEndpoint: true}).Server.Handler
+	handler := NewHTTPServer("test", "", &Config{EnableProxyEndpoint: true}).Server.Handler
 	handler.ServeHTTP(rr, req)
 
 	if rr.Code != http.StatusOK {
@@ -312,7 +313,7 @@ func TestAWSHandler(t *testing.T) {
 	}
 
 	rr := httptest.NewRecorder()
-	handler := NewHTTPServer("test", "",  config).Server.Handler
+	handler := NewHTTPServer("test", "", config).Server.Handler
 	handler.ServeHTTP(rr, req)
 
 	if rr.Code != http.StatusOK {

--- a/pkg/infrabin/infrabin.go
+++ b/pkg/infrabin/infrabin.go
@@ -62,10 +62,6 @@ func (s *InfrabinService) Delay(ctx context.Context, request *DelayRequest) (*Re
 	return &Response{Delay: int32(seconds)}, nil
 }
 
-func (s *InfrabinService) Liveness(ctx context.Context, _ *Empty) (*Response, error) {
-	return &Response{Liveness: "pass"}, nil
-}
-
 func (s *InfrabinService) Env(ctx context.Context, request *EnvRequest) (*Response, error) {
 	value := helpers.GetEnv(request.EnvVar, "")
 	if value == "" {

--- a/pkg/infrabin/infrabin.go
+++ b/pkg/infrabin/infrabin.go
@@ -22,7 +22,7 @@ import (
 )
 
 // Must embed UnimplementedInfrabinServer for `protogen-gen-go-grpc`
-type InfrabinService struct{
+type InfrabinService struct {
 	UnimplementedInfrabinServer
 	Config *Config
 }

--- a/proto/grpc/health/v1/health.proto
+++ b/proto/grpc/health/v1/health.proto
@@ -46,7 +46,7 @@ service Health {
   // NOT_FOUND.
   rpc Check(HealthCheckRequest) returns (HealthCheckResponse) {
     option (google.api.http) = {
-        get: "/health"
+        get: "/check"
     };
   };
 

--- a/proto/grpc/health/v1/health.proto
+++ b/proto/grpc/health/v1/health.proto
@@ -1,0 +1,69 @@
+// Copyright 2015 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The canonical version of this proto can be found at
+// https://github.com/grpc/grpc-proto/blob/master/grpc/health/v1/health.proto
+
+syntax = "proto3";
+
+package grpc.health.v1;
+
+import "google/api/annotations.proto";
+
+option csharp_namespace = "Grpc.Health.V1";
+option go_package = "google.golang.org/grpc/health/grpc_health_v1";
+option java_multiple_files = true;
+option java_outer_classname = "HealthProto";
+option java_package = "io.grpc.health.v1";
+
+message HealthCheckRequest {
+  string service = 1;
+}
+
+message HealthCheckResponse {
+  enum ServingStatus {
+    UNKNOWN = 0;
+    SERVING = 1;
+    NOT_SERVING = 2;
+    SERVICE_UNKNOWN = 3;  // Used only by the Watch method.
+  }
+  ServingStatus status = 1;
+}
+
+service Health {
+  // If the requested service is unknown, the call will fail with status
+  // NOT_FOUND.
+  rpc Check(HealthCheckRequest) returns (HealthCheckResponse) {
+    option (google.api.http) = {
+        get: "/health"
+    };
+  };
+
+  // Performs a watch for the serving status of the requested service.
+  // The server will immediately send back a message indicating the current
+  // serving status.  It will then subsequently send a new message whenever
+  // the service's serving status changes.
+  //
+  // If the requested service is unknown when the call is received, the
+  // server will send a message setting the serving status to
+  // SERVICE_UNKNOWN but will *not* terminate the call.  If at some
+  // future point, the serving status of the service becomes known, the
+  // server will send a new message with the service's serving status.
+  //
+  // If the call terminates with status UNIMPLEMENTED, then clients
+  // should assume this method is not supported and should not retry the
+  // call.  If the call terminates with any other status (including OK),
+  // clients should retry the call with appropriate exponential backoff.
+  rpc Watch(HealthCheckRequest) returns (stream HealthCheckResponse);
+}

--- a/proto/infrabin/infrabin.proto
+++ b/proto/infrabin/infrabin.proto
@@ -4,6 +4,7 @@ package infrabin;
 
 import "google/protobuf/struct.proto";
 import "google/api/annotations.proto";
+// import "grpc/health/v1/health.proto";
 
 option go_package = "github.com/maruina/go-infrabin/pkg/infrabin;infrabin";
 
@@ -49,6 +50,14 @@ service Infrabin {
         };
     }
 }
+
+//service grpc.health.v1.Health {
+//  rpc Check(grpc.health.v1.HealthCheckRequest) returns (grpc.health.v1.HealthCheckResponse) {
+//    option (google.api.http) = {
+//      get: "/liveness"
+//    };
+//  };
+//}
 
 
 // Empty is the null value for parameters.

--- a/proto/infrabin/infrabin.proto
+++ b/proto/infrabin/infrabin.proto
@@ -4,9 +4,8 @@ package infrabin;
 
 import "google/protobuf/struct.proto";
 import "google/api/annotations.proto";
-// import "grpc/health/v1/health.proto";
 
-option go_package = "github.com/maruina/go-infrabin/pkg/infrabin;infrabin";
+option go_package = "github.com/maruina/go-infrabin/pkg/infrabin";
 
 
 // The echo infrabin service replies with the message it received.
@@ -15,11 +14,6 @@ service Infrabin {
     rpc Delay(DelayRequest) returns (Response) {
         option (google.api.http) = {
             get: "/delay/{duration}"
-        };
-    }
-    rpc Liveness(Empty) returns (Response) {
-        option (google.api.http) = {
-            get: "/liveness"
         };
     }
     rpc Env(EnvRequest) returns (Response) {
@@ -50,14 +44,6 @@ service Infrabin {
         };
     }
 }
-
-//service grpc.health.v1.Health {
-//  rpc Check(grpc.health.v1.HealthCheckRequest) returns (grpc.health.v1.HealthCheckResponse) {
-//    option (google.api.http) = {
-//      get: "/liveness"
-//    };
-//  };
-//}
 
 
 // Empty is the null value for parameters.


### PR DESCRIPTION
# Summary

closes #43 

- Uses the built in implementation of the health check service
- This is imported from grpc-go
- grpc-go uses to v1 proto format (this is the problem with being an early adopter
  - I have added some temporary horrible code in the Makefile which wraps the V1 with a `MessageV2` conversion
  - We could move this from "bash" to another standalone go file in `cmd/` if you prefer
- grpc-gateway v2 supports the `standalone` flag which means it imports the (v1) protos which is cool

# Notes

- this is on top of the prometheus branch so we should merge that one first and rebase
