### PR TITLE
Ensure grpc server gracefully shuts down with a drain timeout

### DIFF
--- a/cmd/go-infrabin/main.go
+++ b/cmd/go-infrabin/main.go
@@ -33,7 +33,7 @@ func main() {
 
 	// run grpc server in background
 	grpcServer := infrabin.NewGRPCServer()
-	go grpcServer.ListenAndServe()
+	go grpcServer.ListenAndServe(nil)
 
 	// run service server in background
 	server := infrabin.NewHTTPServer(

--- a/pkg/infrabin/config.go
+++ b/pkg/infrabin/config.go
@@ -2,6 +2,7 @@ package infrabin
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/spf13/viper"
 )
@@ -43,6 +44,9 @@ func ReadConfiguration() {
 
 	// Other Infrastructure Defaults
 	viper.SetDefault("awsMetadataEndpoint", "http://169.254.169.254/latest/meta-data/")
+
+	// Graceful timeout duration
+	viper.SetDefault("drainTimeout", 15*time.Second)
 
 	if err := viper.ReadInConfig(); err != nil {
 		if _, ok := err.(viper.ConfigFileNotFoundError); ok {

--- a/pkg/infrabin/grpc_test.go
+++ b/pkg/infrabin/grpc_test.go
@@ -2,6 +2,7 @@ package infrabin
 
 import (
 	"context"
+	"log"
 	"net"
 	"testing"
 	"time"
@@ -29,7 +30,11 @@ func TestShutdown(t *testing.T) {
 
 	// Create server and client
 	lis := bufconn.Listen(1024 * 1024) // use a bufconn listener for testing
+	// Start server
 	server := NewGRPCServer()
+	go server.ListenAndServe(lis)
+
+	// Create connection, dialier, and client
 	conn, err := grpc.DialContext(
 		context.Background(),
 		"bufnet",
@@ -41,30 +46,31 @@ func TestShutdown(t *testing.T) {
 	}
 	defer conn.Close()
 	client := NewInfrabinClient(conn)
+
 	// We make a channel for errors as we cannot call t.Fatal inside a non test goroutine
 	errs := make(chan error, 1)
 
-	// Start server, call Delay for longer than graceful stop
-	go server.ListenAndServe(lis)
-	// Wait enough time for server to have started
-	time.Sleep(100 * time.Millisecond)
 	start := time.Now()
 	// Call delay with 2 * drainTimeout (1s) in the background
 	go func() {
+		log.Println("Calling Delay gRPC method")
 		if _, err := client.Delay(context.Background(), &DelayRequest{Duration: 1}); err != nil {
 			errs <- err
 		}
 	}()
+	// Make sure Serve and Delay are called
+	time.Sleep(200 * time.Millisecond)
 	// Start the shutdown
 	server.Shutdown()
 	elapsed := time.Since(start).Milliseconds()
 
 	// Check the shutdown waits for at least 500ms, but not the full duration 1s
+	// Should take ~700ms (200ms wait + 500ms drainTimeout)
 	if elapsed < drainTimeout.Milliseconds() || elapsed > 1000 {
-		t.Fail()
+		t.Errorf("Shutdown didn't take expected time. Took %d milliseconds", elapsed)
 	}
 	// There should be an error calling delay as we force stop before
 	if err = <-errs; err == nil {
-		t.Fail()
+		t.Error("The call to Delay didn't error. We expect it to fail as the Shutdown.")
 	}
 }

--- a/pkg/infrabin/grpc_test.go
+++ b/pkg/infrabin/grpc_test.go
@@ -1,11 +1,70 @@
 package infrabin
 
-import "testing"
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/spf13/viper"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/test/bufconn"
+)
 
 func TestNewGRPCServer(t *testing.T) {
 
 	server := NewGRPCServer()
 	if server.Name != "grpc" {
 		t.Errorf("Name not set on GRPCServer. got %v want %v", server.Name, "grpc")
+	}
+}
+
+// Test that graceful stop only waits for drainTimeout, not longer
+func TestShutdown(t *testing.T) {
+	// Mark test as parallel so it can happen in the background
+	t.Parallel()
+	// Override drainTimeout for test
+	drainTimeout := 500 * time.Millisecond
+	viper.Set("drainTimeout", drainTimeout)
+
+	// Create server and client
+	lis := bufconn.Listen(1024 * 1024) // use a bufconn listener for testing
+	server := NewGRPCServer()
+	conn, err := grpc.DialContext(
+		context.Background(),
+		"bufnet",
+		grpc.WithContextDialer(func(ctx context.Context, address string) (net.Conn, error) { return lis.Dial() }),
+		grpc.WithInsecure(),
+	)
+	if err != nil {
+		t.Fatal(err) // could not set up test listener
+	}
+	defer conn.Close()
+	client := NewInfrabinClient(conn)
+	// We make a channel for errors as we cannot call t.Fatal inside a non test goroutine
+	errs := make(chan error, 1)
+
+	// Start server, call Delay for longer than graceful stop
+	go server.ListenAndServe(lis)
+	// Wait enough time for server to have started
+	time.Sleep(100 * time.Millisecond)
+	start := time.Now()
+	// Call delay with 2 * drainTimeout (1s) in the background
+	go func() {
+		if _, err := client.Delay(context.Background(), &DelayRequest{Duration: 1}); err != nil {
+			errs <- err
+		}
+	}()
+	// Start the shutdown
+	server.Shutdown()
+	elapsed := time.Since(start).Milliseconds()
+
+	// Check the shutdown waits for at least 500ms, but not the full duration 1s
+	if elapsed < drainTimeout.Milliseconds() || elapsed > 1000 {
+		t.Fail()
+	}
+	// There should be an error calling delay as we force stop before
+	if err = <-errs; err == nil {
+		t.Fail()
 	}
 }

--- a/pkg/infrabin/http.go
+++ b/pkg/infrabin/http.go
@@ -72,8 +72,9 @@ func (s *HTTPServer) ListenAndServe() {
 }
 
 func (s *HTTPServer) Shutdown() {
-	log.Printf("Shutting down %s server with 15s graceful shutdown", s.Name)
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	drainTimeout := viper.GetDuration("drainTimeout")
+	log.Printf("Shutting down %s server with %s graceful shutdown", s.Name, drainTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), drainTimeout)
 	defer cancel()
 
 	if err := s.Server.Shutdown(ctx); err != nil {


### PR DESCRIPTION
# Summary

- add `drainTimeout` config option defaulting to 15s
- use `drainTimeout` in http and grpc `Shutdown`
- ensure that grpc Shutdown does actually wait for that time and then force quit
- add a test (which is hopefully well commented) to test this behaviour

# Notes to reviewer
- the test is the heaviest part of this
- it is marked as parallel to ensure that it runs in the background while other tests run
- it does sleep, so we override the `drianTimeout` to 500ms

