### PR TITLE
Move timeouts to viper config. Fix WriteTimeout for long delay.

### DIFF
--- a/internal/helpers/math.go
+++ b/internal/helpers/math.go
@@ -1,7 +1,9 @@
 package helpers
 
+import "time"
+
 // Min returns the smaller of x or y.
-func Min(x, y int) int {
+func MinDuration(x, y time.Duration) time.Duration {
 	if x > y {
 		return y
 	}

--- a/internal/helpers/math_test.go
+++ b/internal/helpers/math_test.go
@@ -2,19 +2,20 @@ package helpers
 
 import (
 	"testing"
+	"time"
 )
 
 func TestMin(t *testing.T) {
-	var x, y int = 5, 3
-	min := Min(x, y)
+	var x, y time.Duration = 5 * time.Second, 3 * time.Second
+	min := MinDuration(x, y)
 	if min != y {
 		t.Errorf("Min returned unexpected value: got %v want %v", min, y)
 	}
 }
 
 func TestMinSwapped(t *testing.T) {
-	var x, y int = 3, 5
-	min := Min(x, y)
+	var x, y time.Duration = 3 * time.Second, 5 * time.Second
+	min := MinDuration(x, y)
 	if min != x {
 		t.Errorf("Min returned unexpected value: got %v want %v", min, x)
 	}

--- a/pkg/infrabin/config.go
+++ b/pkg/infrabin/config.go
@@ -48,6 +48,16 @@ func ReadConfiguration() {
 	// Graceful timeout duration
 	viper.SetDefault("drainTimeout", 15*time.Second)
 
+	// Max delay duration for Delay endpoint
+	maxDelay := 120 * time.Second
+	viper.SetDefault("maxDelay", maxDelay)
+
+	// http timeouts
+	viper.SetDefault("httpWriteTimeout", maxDelay+time.Second)
+	viper.SetDefault("httpReadTimeout", 60*time.Second)
+	viper.SetDefault("httpIdleTimeout", 15*time.Second)
+	viper.SetDefault("httpReadHeaderTimeout", 15*time.Second)
+
 	if err := viper.ReadInConfig(); err != nil {
 		if _, ok := err.(viper.ConfigFileNotFoundError); ok {
 			// Will just use the default configuration.

--- a/pkg/infrabin/http.go
+++ b/pkg/infrabin/http.go
@@ -5,7 +5,6 @@ import (
 	"log"
 	"net/http"
 	"strings"
-	"time"
 
 	grpc_health_v1 "github.com/maruina/go-infrabin/pkg/grpc/health/v1"
 	"github.com/spf13/viper"
@@ -95,10 +94,10 @@ func NewHTTPServer(name string, opts ...HTTPServerOption) *HTTPServer {
 		Handler: http.NewServeMux(),
 		Addr:    addr,
 		// Good practice: enforce timeouts
-		WriteTimeout:      15 * time.Second,
-		ReadTimeout:       15 * time.Second,
-		IdleTimeout:       30 * time.Second,
-		ReadHeaderTimeout: 2 * time.Second,
+		WriteTimeout:      viper.GetDuration("httpWriteTimeout"),
+		ReadTimeout:       viper.GetDuration("httpReadTimeout"),
+		IdleTimeout:       viper.GetDuration("httpIdleTimeout"),
+		ReadHeaderTimeout: viper.GetDuration("httpReadHeaderTimeout"),
 	}
 
 	s := &HTTPServer{Name: name, Server: server}


### PR DESCRIPTION
# Summary

- remove `INFRABIN_MAX_DELAY` in favour of viper config
- move hard coded http timeouts to viper config
- ensure that WriteTimeous is at least maxDelay + 1s
- change Min to MaxDuration
- update tests
