### PR TITLE
Add support for SIGTERM

### DIFF
--- a/cmd/go-infrabin/main.go
+++ b/cmd/go-infrabin/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"os"
 	"os/signal"
+	"syscall"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/spf13/viper"
@@ -15,8 +16,9 @@ func main() {
 	// Create a channel to catch signals
 	finish := make(chan os.Signal, 1)
 	// We'll accept graceful shutdowns when quit via SIGINT (Ctrl+C)
-	// SIGKILL, SIGQUIT or SIGTERM (Ctrl+/) will not be caught.
-	signal.Notify(finish, os.Interrupt)
+	// and SIGTERM (used in docker and kubernetes)
+	// SIGKILL or SIGQUIT will not be caught.
+	signal.Notify(finish, syscall.SIGINT, syscall.SIGTERM)
 
 	// Parse the configuration or set default configuration
 	infrabin.ReadConfiguration()


### PR DESCRIPTION
Make sure we handle correctly `SIGTERM`. This signal is used in Kubernetes (see https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination) and Docker (see https://docs.docker.com/engine/reference/commandline/stop/)

This will allow go-infrabin to do a graceful shutdown when run as a container or kubernetes pod.
