### PR TITLE
Remove arm64 build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,7 +68,6 @@ jobs:
       uses: docker/build-push-action@v2.7.0
       with:
         push: true
-        platforms: linux/amd64,linux/arm64
         tags: |
           docker.io/maruina/go-infrabin:latest
           ghcr.io/maruina/go-infrabin:latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,6 @@ jobs:
       uses: docker/build-push-action@v2.7.0
       with:
         push: true
-        platforms: linux/amd64,linux/arm64
         tags: |
           docker.io/maruina/go-infrabin:${{ steps.tagName.outputs.tag }}
           ghcr.io/maruina/go-infrabin:${{ steps.tagName.outputs.tag }}


### PR DESCRIPTION
Commit https://github.com/maruina/go-infrabin/commit/070d21116758ab50ef9851aaea1626047a264eb8 broke the build on master as we need more work to support arm64. See https://github.com/maruina/go-infrabin/pull/167