### PR TITLE
Move to multi arch build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,7 @@ jobs:
       uses: docker/build-push-action@v5.1.0
       with:
         push: true
+        platforms: linux/amd64,linux/arm64
         tags: |
           docker.io/maruina/go-infrabin:${{ steps.tagName.outputs.tag }}
           ghcr.io/maruina/go-infrabin:${{ steps.tagName.outputs.tag }}


### PR DESCRIPTION
# Summary

This updates `build-and-push` to use `platforms: linux/amd64,linux/arm64`
It also upgrade `build-and-push` to `5.3.0`